### PR TITLE
Add support for text run properties

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/openxml/openxml-drawingml.git
-  revision: f5b93460bf1c94b0881f6b220e914c5a59d84dbd
+  revision: eb0f94d5dcfd892364d2183be19ac5cc47c5dd90
   branch: master
   specs:
     openxml-drawingml (0.1.0)

--- a/lib/openxml/elements/run_properties.rb
+++ b/lib/openxml/elements/run_properties.rb
@@ -1,0 +1,47 @@
+module OpenXml
+  module Elements
+    class RunProperties < OpenXml::Element
+      namespace :a
+      tag :rPr
+
+      attribute :italic, displays_as: :i, expects: :boolean
+      attribute :bold, displays_as: :b, expects: :boolean
+      attribute :size, displays_as: :sz, one_of: (100..400_000).to_a
+      attribute :strike, one_of: %w[sngStrike dblStrike noStrike]
+      attribute :underline, displays_as: :u, one_of: %w[
+        dash
+        dashHeavy
+        dashLong
+        dashLongHeavy
+        dbl
+        dotDash
+        dotDashHeavy
+        dotDotDash
+        dotDotDashHeavy
+        dotted
+        dottedHeavy
+        heavy
+        none
+        sng
+        wavy
+        wavyDbl
+        wavyHeavy
+        words
+      ]
+
+      def initialize(*boolean_properties, **value_properties)
+        boolean_properties.each do |property|
+          public_send("#{property}=", true)
+        end
+
+        value_properties.each do |property, value|
+          public_send("#{property}=", value)
+        end
+      end
+
+      def to_xml(xml)
+        super if render?
+      end
+    end
+  end
+end

--- a/lib/openxml/extract/attribute_builder.rb
+++ b/lib/openxml/extract/attribute_builder.rb
@@ -116,7 +116,7 @@ module OpenXml
     end
 
     def valid_in?(value, list)
-      message = "Invalid #{name}: must be one of #{list.join(", ")} (was #{value.inspect})"
+      message = "Invalid #{name}: must be one of #{list} (was #{value.inspect})"
       raise ArgumentError, message unless list.member?(value)
     end
 

--- a/lib/openxml/shapes/text.rb
+++ b/lib/openxml/shapes/text.rb
@@ -4,6 +4,7 @@ require "openxml/elements/paragraph"
 require "openxml/elements/run"
 require "openxml/elements/text"
 require "openxml/elements/body_properties"
+require "openxml/elements/run_properties"
 require "openxml/pptx/elements/shape_properties"
 require "openxml/pptx/elements/nonvisual_drawing_properties"
 require "openxml/pptx/elements/nonvisual_shape_drawing_properties"
@@ -12,15 +13,26 @@ require "openxml/pptx/elements/nonvisual_properties"
 module OpenXml
   module Shapes
     class Text
+      attr_writer :boolean_properties, :value_properties
       attr_accessor :text, :bounds
       private :text=, :bounds=
 
-      def initialize(text, bounds)
+      def initialize(text, bounds, *boolean_properties, **value_properties)
         self.text = text
         self.bounds = bounds
+        self.boolean_properties = boolean_properties
+        self.value_properties = value_properties
       end
 
       def add_to(parent)
+      end
+
+      def boolean_properties
+        @boolean_properties.clone
+      end
+
+      def value_properties
+        @value_properties.clone
       end
 
       def to_xml(xml)
@@ -55,6 +67,7 @@ module OpenXml
           text_body << OpenXml::Elements::BodyProperties.new
           text_body << OpenXml::Elements::Paragraph.new.tap { |paragraph|
             paragraph << OpenXml::Elements::Run.new.tap { |run|
+              run << OpenXml::Elements::RunProperties.new(*boolean_properties, **value_properties)
               run << OpenXml::Elements::Text.new(text)
             }
           }

--- a/spec/openxml/elements/run_properties_spec.rb
+++ b/spec/openxml/elements/run_properties_spec.rb
@@ -104,11 +104,11 @@ RSpec.describe OpenXml::Elements::RunProperties do
     end
 
     failure_message do
-      "expected all values to be accepted, but #{@failures} were not accepted"
+      "expected all values to be accepted, but #{@failures} were rejected"
     end
 
     failure_message_when_negated do
-      "expected all values to not be accepted, but #{@failures} were accepted"
+      "expected all values to be rejected, but #{@failures} were accepted"
     end
 
     chain :in, :values

--- a/spec/openxml/elements/run_properties_spec.rb
+++ b/spec/openxml/elements/run_properties_spec.rb
@@ -1,0 +1,120 @@
+require "spec_helper"
+require "support/matchers/generate_tag"
+require "openxml/elements/run_properties"
+
+RSpec.describe OpenXml::Elements::RunProperties do
+  context "with no set properties" do
+    it do
+      is_expected.to generate_tag("")
+    end
+  end
+
+  context "with properties" do
+    subject { described_class.new(:italic, size: 100) }
+    it do
+      is_expected.to generate_tag("<a:rPr i='true' sz='100'/>")
+    end
+  end
+
+  it do
+    is_expected.to have_boolean_attribute(:italic)
+  end
+
+  it do
+    is_expected.to have_boolean_attribute(:bold)
+  end
+
+  it do
+    is_expected.to support_value_property(:size).in_range(100..400_000)
+  end
+
+  it do
+    is_expected.to_not support_value_property(:size).in([99, 400_001, -100])
+  end
+
+  it do
+    is_expected.to support_value_property(:strike).in(%w[sngStrike dblStrike noStrike])
+  end
+
+  it do
+    is_expected.to_not support_value_property(:strike).in(%w[not_supported])
+  end
+
+  it do
+    is_expected.to support_value_property(:underline).in(%w[
+                                                         dash
+                                                         dashHeavy
+                                                         dashLong
+                                                         dashLongHeavy
+                                                         dbl
+                                                         dotDash
+                                                         dotDashHeavy
+                                                         dotDotDash
+                                                         dotDotDashHeavy
+                                                         dotted
+                                                         dottedHeavy
+                                                         heavy
+                                                         none
+                                                         sng
+                                                         wavy
+                                                         wavyDbl
+                                                         wavyHeavy
+                                                         words
+    ])
+  end
+
+  it do
+    is_expected.to_not support_value_property(:underline).in(%w[not_supported])
+  end
+
+  matcher :have_boolean_attribute do |attribute|
+    match do
+      instance = described_class.new(attribute)
+      instance.public_send(attribute) == true
+    end
+  end
+
+  matcher :support_value_property do |attribute|
+    match do
+      @failures = []
+      Array(values).each do |val|
+        begin
+          instance = described_class.new(attribute => val)
+          @failures.push val  unless instance.public_send(attribute) == val
+        rescue ArgumentError
+          @failures.push val
+        end
+      end
+
+      @failures.empty?
+    end
+
+    match_when_negated do
+      @failures = []
+
+      Array(values).each do |val|
+        begin
+          instance = described_class.new(attribute => val)
+          @failures.push val
+        rescue ArgumentError
+        end
+      end
+
+      @failures.empty?
+    end
+
+    failure_message do
+      "expected all values to be accepted, but #{@failures} were not accepted"
+    end
+
+    failure_message_when_negated do
+      "expected all values to not be accepted, but #{@failures} were accepted"
+    end
+
+    chain :in, :values
+
+    chain :in_range do |range|
+      @values = [range.first, range.last]
+    end
+  end
+end

--- a/spec/shapes/text_spec.rb
+++ b/spec/shapes/text_spec.rb
@@ -4,9 +4,11 @@ require "openxml/shapes/text"
 require "openxml/shapes/bounds"
 
 RSpec.describe OpenXml::Shapes::Text do
-  describe "with 'Hello World' inside" do
-    let(:bounds) { OpenXml::Shapes::Bounds.new(0, 0, 1465546, 369333)}
-    subject { described_class.new("Hello World", bounds) }
+  let(:bounds) { OpenXml::Shapes::Bounds.new(0, 0, 1465546, 369333)}
+  let(:text) { "Hello World" }
+
+  describe "with no formating" do
+    subject { described_class.new(text, bounds) }
 
     specify do
       expect(subject.text).to eql("Hello World")
@@ -30,6 +32,72 @@ RSpec.describe OpenXml::Shapes::Text do
             <a:bodyPr/>
             <a:p>
               <a:r>
+                <a:t>Hello World</a:t>
+              </a:r>
+            </a:p>
+          </p:txBody>
+        </p:sp>
+      """
+
+      is_expected.to generate_tag(expected_output)
+    end
+  end
+
+  describe "with italic" do
+    subject { described_class.new(text, bounds, :italic) }
+
+    it do
+      expected_output = """
+        <p:sp>
+          <p:nvSpPr>
+            <p:cNvPr id='#{subject.object_id}' name='TextBox'/>
+            <p:cNvSpPr/>
+            <p:nvPr/>
+          </p:nvSpPr>
+          <p:spPr>
+            <a:xfrm>
+              <a:off x='0' y='0'/>
+              <a:ext cx='1465546' cy='369333'/>
+            </a:xfrm>
+          </p:spPr>
+          <p:txBody>
+            <a:bodyPr/>
+            <a:p>
+              <a:r>
+                <a:rPr i='true'/>
+                <a:t>Hello World</a:t>
+              </a:r>
+            </a:p>
+          </p:txBody>
+        </p:sp>
+      """
+
+      is_expected.to generate_tag(expected_output)
+    end
+  end
+
+  describe "with size" do
+    subject { described_class.new(text, bounds, size: 4000) }
+
+    it do
+      expected_output = """
+        <p:sp>
+          <p:nvSpPr>
+            <p:cNvPr id='#{subject.object_id}' name='TextBox'/>
+            <p:cNvSpPr/>
+            <p:nvPr/>
+          </p:nvSpPr>
+          <p:spPr>
+            <a:xfrm>
+              <a:off x='0' y='0'/>
+              <a:ext cx='1465546' cy='369333'/>
+            </a:xfrm>
+          </p:spPr>
+          <p:txBody>
+            <a:bodyPr/>
+            <a:p>
+              <a:r>
+                <a:rPr sz='4000'/>
                 <a:t>Hello World</a:t>
               </a:r>
             </a:p>


### PR DESCRIPTION
This does not support all properties, but it does support all the
formatting properties that are directly on a run. This definitely
excludes colors which will need to be handled differently.

Amos King @adkron <amos@binarynoggin.com>