### PR TITLE
Add support to color text

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/openxml/openxml-drawingml.git
-  revision: eb0f94d5dcfd892364d2183be19ac5cc47c5dd90
+  revision: ed44ecc10fbdf829340530fb13482f223352dbde
   branch: master
   specs:
     openxml-drawingml (0.1.0)

--- a/lib/openxml/elements/latin.rb
+++ b/lib/openxml/elements/latin.rb
@@ -1,0 +1,13 @@
+module OpenXml
+  module Elements
+    class Latin < OpenXml::Element
+      namespace :a
+      tag :latin
+      attribute :typeface, expects: :string
+
+      def initialize(typeface)
+        self.typeface = typeface
+      end
+    end
+  end
+end

--- a/lib/openxml/elements/rgb_color.rb
+++ b/lib/openxml/elements/rgb_color.rb
@@ -1,0 +1,15 @@
+module OpenXml
+  module Elements
+    class RGBColor < OpenXml::Element
+      namespace :a
+      tag :srgbClr
+      name :rgb_color
+
+      attribute :hex, displays_as: :val, expects: :hex_color
+
+      def initialize(color)
+        self.hex = color
+      end
+    end
+  end
+end

--- a/lib/openxml/elements/run_properties.rb
+++ b/lib/openxml/elements/run_properties.rb
@@ -32,8 +32,11 @@ module OpenXml
         words
       ]
 
-      def initialize(*boolean_properties, **value_properties)
+      def initialize(*boolean_properties, font_color: nil, typeface: nil, **value_properties)
         super()
+
+        self.font_color = font_color
+        self.typeface = typeface
 
         boolean_properties.each do |property|
           public_send("#{property}=", true)
@@ -44,17 +47,20 @@ module OpenXml
         end
       end
 
-      def font_color=(color)
-        self.push(OpenXml::Elements::RGBColor.new(color))
-      end
-
-      def typeface=(typeface)
-        self.push(OpenXml::Elements::Latin.new(typeface))
-      end
-
       def to_xml(xml)
         super if render?
       end
+
+      private def font_color=(color)
+        return if color.nil?
+        self.push(OpenXml::Elements::RGBColor.new(color))
+      end
+
+      private def typeface=(typeface)
+        return if typeface.nil?
+        self.push(OpenXml::Elements::Latin.new(typeface))
+      end
+
     end
   end
 end

--- a/lib/openxml/elements/run_properties.rb
+++ b/lib/openxml/elements/run_properties.rb
@@ -1,6 +1,8 @@
+require "openxml/elements/rgb_color"
+
 module OpenXml
   module Elements
-    class RunProperties < OpenXml::Element
+    class RunProperties < OpenXml::Container
       namespace :a
       tag :rPr
 
@@ -30,6 +32,8 @@ module OpenXml
       ]
 
       def initialize(*boolean_properties, **value_properties)
+        super()
+
         boolean_properties.each do |property|
           public_send("#{property}=", true)
         end
@@ -37,6 +41,10 @@ module OpenXml
         value_properties.each do |property, value|
           public_send("#{property}=", value)
         end
+      end
+
+      def font_color=(color)
+        self.push(OpenXml::Elements::RGBColor.new(color))
       end
 
       def to_xml(xml)

--- a/lib/openxml/elements/run_properties.rb
+++ b/lib/openxml/elements/run_properties.rb
@@ -1,4 +1,5 @@
 require "openxml/elements/rgb_color"
+require "openxml/elements/latin"
 
 module OpenXml
   module Elements
@@ -45,6 +46,10 @@ module OpenXml
 
       def font_color=(color)
         self.push(OpenXml::Elements::RGBColor.new(color))
+      end
+
+      def typeface=(typeface)
+        self.push(OpenXml::Elements::Latin.new(typeface))
       end
 
       def to_xml(xml)

--- a/lib/openxml/extract/container.rb
+++ b/lib/openxml/extract/container.rb
@@ -19,5 +19,9 @@ module OpenXml
         children.each { |child| child.to_xml(xml) }
       }
     end
+
+    def render?
+      super || children.any?
+    end
   end
 end

--- a/spec/openxml/elements/rgb_color_spec.rb
+++ b/spec/openxml/elements/rgb_color_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+require "support/matchers/generate_tag"
+require "openxml/elements/run_properties"
+
+RSpec.describe OpenXml::Elements::RGBColor do
+  context "with string hex value" do
+    subject { described_class.new("929292") }
+
+    it do
+      is_expected.to generate_tag("<a:srgbClr val='929292'/>")
+    end
+  end
+
+  context "with a string that isn't valid hex" do
+    specify do
+      expect{ described_class.new("FGGFFG") }.to raise_error(ArgumentError)
+    end
+  end
+end

--- a/spec/openxml/elements/run_properties_spec.rb
+++ b/spec/openxml/elements/run_properties_spec.rb
@@ -28,6 +28,18 @@ RSpec.describe OpenXml::Elements::RunProperties do
     end
   end
 
+  context "with typeface" do
+    subject { described_class.new(typeface: "Arial") }
+    it do
+      is_expected.to generate_tag(<<~XML
+                                  <a:rPr>
+                                    <a:latin typeface='Arial'/>
+                                  </a:Pr>
+                                 XML
+                                 )
+    end
+  end
+
   it do
     is_expected.to have_boolean_attribute(:italic)
   end

--- a/spec/openxml/elements/run_properties_spec.rb
+++ b/spec/openxml/elements/run_properties_spec.rb
@@ -16,6 +16,18 @@ RSpec.describe OpenXml::Elements::RunProperties do
     end
   end
 
+  context "with font color" do
+    subject { described_class.new(font_color: "929292") }
+    it do
+      is_expected.to generate_tag(<<~XML
+                                  <a:rPr>
+                                    <a:srgbClr val='929292'/>
+                                  </a:Pr>
+                                 XML
+                                 )
+    end
+  end
+
   it do
     is_expected.to have_boolean_attribute(:italic)
   end

--- a/spec/openxml/elements/run_properties_spec.rb
+++ b/spec/openxml/elements/run_properties_spec.rb
@@ -9,8 +9,17 @@ RSpec.describe OpenXml::Elements::RunProperties do
     end
   end
 
+  it do
+    is_expected.to only_allow_initial_setting_of(:font_color)
+  end
+
+  it do
+    is_expected.to only_allow_initial_setting_of(:typeface)
+  end
+
   context "with properties" do
     subject { described_class.new(:italic, size: 100) }
+
     it do
       is_expected.to generate_tag("<a:rPr i='true' sz='100'/>")
     end
@@ -18,6 +27,7 @@ RSpec.describe OpenXml::Elements::RunProperties do
 
   context "with font color" do
     subject { described_class.new(font_color: "929292") }
+
     it do
       is_expected.to generate_tag(<<~XML
                                   <a:rPr>
@@ -30,6 +40,7 @@ RSpec.describe OpenXml::Elements::RunProperties do
 
   context "with typeface" do
     subject { described_class.new(typeface: "Arial") }
+
     it do
       is_expected.to generate_tag(<<~XML
                                   <a:rPr>
@@ -141,4 +152,11 @@ RSpec.describe OpenXml::Elements::RunProperties do
       @values = [range.first, range.last]
     end
   end
+
+  matcher :only_allow_initial_setting_of do |property|
+    match do
+      expect{subject.public_send("#{property}=", "a")}.to raise_error(NoMethodError, /private method/)
+    end
+  end
+
 end


### PR DESCRIPTION
```ruby
    OpenXml::Elements::RunProperties.new(font_color: "929292")
```

I chose to use `font_color` becuase I thought it was more relatable to
people who use CSS regularly. I also think that we are going to need a
background_color too.

Amos King @adkron <amos@binarynoggin.com>