### PR TITLE
Fix for corrupted pptx output.

### DIFF
--- a/lib/openxml/pptx.rb
+++ b/lib/openxml/pptx.rb
@@ -1,5 +1,6 @@
 module OpenXml
   module Pptx
+    MAX_ID_SIZE = 2**31 - 1
   end
 end
 

--- a/lib/openxml/pptx/elements/slide_id_list.rb
+++ b/lib/openxml/pptx/elements/slide_id_list.rb
@@ -4,7 +4,6 @@ module OpenXml
   module Pptx
     module Elements
       class SlideId < OpenXml::Element
-        MAX_SIZE = 2**31 - 1
         tag :sldId
 
         attribute :rid, displays_as: :id, expects: :string, namespace: :r
@@ -13,7 +12,7 @@ module OpenXml
         def initialize(relationship_id)
           super()
           self.rid = relationship_id.to_s
-          self.id = object_id % MAX_SIZE
+          self.id = object_id % OpenXml::Pptx::MAX_ID_SIZE
         end
       end
 

--- a/lib/openxml/shapes/image.rb
+++ b/lib/openxml/shapes/image.rb
@@ -53,7 +53,7 @@ module OpenXml
           OpenXml::Pptx::Elements::NonVisualPictureProperties.new.tap { |nv_pic_property|
           nv_pic_property <<
           OpenXml::Pptx::Elements::NonvisualDrawingProperties.new.tap { |nvdp|
-            nvdp.id = object_id
+            nvdp.id = object_id % OpenXml::Pptx::MAX_ID_SIZE
             nvdp.name = "Picture"
           }
           nv_pic_property << OpenXml::Pptx::Elements::NonVisualPictrueDrawingProperties.new

--- a/lib/openxml/shapes/text.rb
+++ b/lib/openxml/shapes/text.rb
@@ -46,7 +46,7 @@ module OpenXml
       def nonvisual_shape_property
         @nonvisual_shape_property ||= OpenXml::Pptx::Elements::ShapeNonVisual.new.tap {|nv_shape_property|
           nv_shape_property << OpenXml::Pptx::Elements::NonvisualDrawingProperties.new.tap { |nvdp|
-            nvdp.id = object_id
+            nvdp.id = object_id % OpenXml::Pptx::MAX_ID_SIZE
             nvdp.name = "TextBox"
           }
           nv_shape_property << OpenXml::Pptx::Elements::NonvisualShapeDrawingProperties.new

--- a/spec/shapes/image_spec.rb
+++ b/spec/shapes/image_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe OpenXml::Shapes::Image do
       expected_output = """
       <p:pic>
         <p:nvPicPr>
-          <p:cNvPr id='#{subject.object_id}' name='Picture'/>
+          <p:cNvPr id='#{subject.object_id % OpenXml::Pptx::MAX_ID_SIZE}' name='Picture'/>
           <p:cNvPicPr/>
           <p:nvPr/>
         </p:nvPicPr>

--- a/spec/shapes/text_spec.rb
+++ b/spec/shapes/text_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe OpenXml::Shapes::Text do
       expected_output = """
         <p:sp>
           <p:nvSpPr>
-            <p:cNvPr id='#{subject.object_id}' name='TextBox'/>
+            <p:cNvPr id='#{subject.object_id % OpenXml::Pptx::MAX_ID_SIZE}' name='TextBox'/>
             <p:cNvSpPr/>
             <p:nvPr/>
           </p:nvSpPr>
@@ -50,7 +50,7 @@ RSpec.describe OpenXml::Shapes::Text do
       expected_output = """
         <p:sp>
           <p:nvSpPr>
-            <p:cNvPr id='#{subject.object_id}' name='TextBox'/>
+            <p:cNvPr id='#{subject.object_id % OpenXml::Pptx::MAX_ID_SIZE}' name='TextBox'/>
             <p:cNvSpPr/>
             <p:nvPr/>
           </p:nvSpPr>
@@ -83,7 +83,7 @@ RSpec.describe OpenXml::Shapes::Text do
       expected_output = """
         <p:sp>
           <p:nvSpPr>
-            <p:cNvPr id='#{subject.object_id}' name='TextBox'/>
+            <p:cNvPr id='#{subject.object_id % OpenXml::Pptx::MAX_ID_SIZE}' name='TextBox'/>
             <p:cNvSpPr/>
             <p:nvPr/>
           </p:nvSpPr>


### PR DESCRIPTION
This patch adds a max size to the object id in the text shape.  Without this fix, PowerPoint considers the pptx to be corrupted.