### PR TITLE
Fix for performance issue with RunProperties object creation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/openxml/openxml-drawingml.git
-  revision: ed44ecc10fbdf829340530fb13482f223352dbde
+  revision: 7bf00c8ea62f4a71250be9cb069bfad4d78620d5
   branch: master
   specs:
     openxml-drawingml (0.1.0)

--- a/lib/openxml/elements/run_properties.rb
+++ b/lib/openxml/elements/run_properties.rb
@@ -9,7 +9,7 @@ module OpenXml
 
       attribute :italic, displays_as: :i, expects: :boolean
       attribute :bold, displays_as: :b, expects: :boolean
-      attribute :size, displays_as: :sz, one_of: (100..400_000).to_a
+      attribute :size, displays_as: :sz, in_range: (100..400_000)
       attribute :strike, one_of: %w[sngStrike dblStrike noStrike]
       attribute :underline, displays_as: :u, one_of: %w[
         dash


### PR DESCRIPTION
This fix improves the performance of the generation of `RunProperties` objects by replacing 400k string conversions with a simple range check.